### PR TITLE
Emacs のバージョンを 22.1.1 に戻したので Symbol's function definition is void: pc-selection-mode は出ない

### DIFF
--- a/init.d/keybinds.el
+++ b/init.d/keybinds.el
@@ -67,9 +67,8 @@
 (global-set-key (kbd "C-\\") 'redo)
 
 ;; シフト + 矢印で範囲選択
-(require 'pc-select)
 (setq pc-select-selection-keys-only t)
-(pc-selection-mode t)
+(pc-selection-mode t) 
 
 ;; タブではなくスペースを挿入する
 (setq-default indent-tabs-mode nil)
@@ -77,3 +76,4 @@
 ;; 論理行ではなく物理行で移動する
 (require 'physical-line)
 (setq-default physical-line-mode t)
+

--- a/init.d/keybinds.el
+++ b/init.d/keybinds.el
@@ -76,4 +76,3 @@
 ;; 論理行ではなく物理行で移動する
 (require 'physical-line)
 (setq-default physical-line-mode t)
-


### PR DESCRIPTION
Emacs のバージョンを 22.1.1 に戻したので Symbol's function definition is void: pc-selection-mode は出ない